### PR TITLE
Load Rails.root + "db/schema.grn" properly

### DIFF
--- a/lib/groonga_client_model/railties/groonga.rake
+++ b/lib/groonga_client_model/railties/groonga.rake
@@ -30,7 +30,7 @@ namespace :groonga do
   namespace :schema do
     desc "Loads db/schema.grn into the Groonga database"
     task load: ["config:load"] do
-      schema_loader = GroongaClientModel::SchemaLoader.new(Rails.root)
+      schema_loader = GroongaClientModel::SchemaLoader.new(Rails.root + "db/schema.grn")
       schema_loader.load
     end
   end

--- a/test/unit/test_schema_loader.rb
+++ b/test/unit/test_schema_loader.rb
@@ -1,0 +1,7 @@
+class TestSchemaLoader < Test::Unit::TestCase
+  test("raise error when load directory") do
+    assert_raise(Errno::EISDIR) do
+      GroongaClientModel::SchemaLoader.new(Pathname.new(".")).load
+    end
+  end
+end


### PR DESCRIPTION
In previous version, `bin/rails groonga:schema:load` does not work.