### PR TITLE
Fix deprecation warning for bold log text in Rails 7.2

### DIFF
--- a/lib/groonga_client_model/log_subscriber.rb
+++ b/lib/groonga_client_model/log_subscriber.rb
@@ -51,10 +51,10 @@ module GroongaClientModel
 
         title = color("#{command.command_name} (#{event.duration.round(1)}ms)",
                       title_color(command),
-                      true)
+                      bold: true)
         formatted_command = color(command.to_command_format,
                                   command_color(command),
-                                  true)
+                                  bold: true)
         "  #{title}  #{formatted_command}"
       end
     end


### PR DESCRIPTION
Replaced positional boolean arguments with option hashes for bolding log text using the `color` method.
This change addresses the following deprecation warnings in Rails 7.2, ensuring compatibility with future Rails versions.

```
Run bin/rails test
2024-08-08 23:47:05 INFO Selenium [:logger_info] Details on how to use and modify Selenium logger:
  https://selenium.dev/documentation/webdriver/troubleshooting/logging

2024-08-08 23:47:05 WARN Selenium [DEPRECATION] DriverFinder.path(options, service_class) is deprecated. Use DriverFinder.new(options, service).driver_path instead.
2024-08-08 23:47:06 WARN Selenium [DEPRECATION] DriverFinder.path(options, service_class) is deprecated. Use DriverFinder.new(options, service).driver_path instead.
DEPRECATION WARNING: Bolding log text with a positional boolean is deprecated and will be removed in Rails 7.2. Use an option hash instead (eg. `color("my text", :red, bold: true)`). (called from block in groonga at /home/runner/work/ranguba/groonga-client-model/lib/groonga_client_model/log_subscriber.rb:52)
DEPRECATION WARNING: Bolding log text with a positional boolean is deprecated and will be removed in Rails 7.2. Use an option hash instead (eg. `color("my text", :red, bold: true)`). (called from block in groonga at /home/runner/work/ranguba/groonga-client-model/lib/groonga_client_model/log_subscriber.rb:55)
```
ref: https://github.com/ranguba/ranguba/actions/runs/10311129722/job/28544124785